### PR TITLE
Disable uninstall bundled extensions

### DIFF
--- a/netlogo-core/src/main/api/LibraryManager.scala
+++ b/netlogo-core/src/main/api/LibraryManager.scala
@@ -151,7 +151,7 @@ class LibraryManager(userExtPath: Path, unloadExtensions: () => Unit) extends Co
 
           val installedVersionPath = s"""$category."$codeName".installedVersion"""
           val installedVersion     = getStringOption(installedLibsConf, installedVersionPath)
-          val bundled              = useBundled && bundledsConfig.hasPath(installedVersionPath) && installedVersion.nonEmpty
+          val bundled              = useBundled && bundledsConfig.hasPath(installedVersionPath) && installedVersion.contains(bundledsConfig.getString(installedVersionPath))
           val minNetLogoVersion    = getStringOption(c, "minNetLogoVersion")
 
           LibraryInfo(name, codeName, shortDesc, longDesc, version, homepage, downloadURL, bundled, installedVersion, minNetLogoVersion)

--- a/netlogo-core/src/main/api/LibraryManager.scala
+++ b/netlogo-core/src/main/api/LibraryManager.scala
@@ -151,11 +151,10 @@ class LibraryManager(userExtPath: Path, unloadExtensions: () => Unit) extends Co
 
           val installedVersionPath = s"""$category."$codeName".installedVersion"""
           val installedVersion     = getStringOption(installedLibsConf, installedVersionPath)
-          val bundled              = useBundled && bundledsConfig.hasPath(installedVersionPath) && installedVersion.isEmpty
+          val bundled              = useBundled && bundledsConfig.hasPath(installedVersionPath) && installedVersion.nonEmpty
           val minNetLogoVersion    = getStringOption(c, "minNetLogoVersion")
 
           LibraryInfo(name, codeName, shortDesc, longDesc, version, homepage, downloadURL, bundled, installedVersion, minNetLogoVersion)
-
       }
 
     infoChangeCallbacks.foreach(_.apply(libraries))

--- a/netlogo-gui/src/main/app/tools/LibrariesTab.scala
+++ b/netlogo-gui/src/main/app/tools/LibrariesTab.scala
@@ -291,7 +291,6 @@ class LibrariesTab( category:        String
       installButton.setEnabled(LibraryInfoDownloader.enabled && actionableLibraries.length > 0)
 
       uninstallButton.setEnabled(LibraryInfoDownloader.enabled && selectedValues.exists(_.canUninstall))
-//            ORIGINAL CODE: uninstallButton.setEnabled(LibraryInfoDownloader.enabled && selectedValues.filter(_.status != LibraryStatus.CanInstall).exists(!_.bundled))
       homepageButton.setEnabled(numSelected == 1)
 
       val installToolTip = if (numSelected == 1) selectedValue.downloadURL.toString else null

--- a/netlogo-gui/src/main/app/tools/LibrariesTab.scala
+++ b/netlogo-gui/src/main/app/tools/LibrariesTab.scala
@@ -290,7 +290,8 @@ class LibrariesTab( category:        String
       installButton.setText(installButtonText)
       installButton.setEnabled(LibraryInfoDownloader.enabled && actionableLibraries.length > 0)
 
-      uninstallButton.setEnabled(LibraryInfoDownloader.enabled && selectedValues.filter(_.status != LibraryStatus.CanInstall).exists(!_.bundled))
+      uninstallButton.setEnabled(LibraryInfoDownloader.enabled && selectedValues.exists(_.canUninstall))
+//            ORIGINAL CODE: uninstallButton.setEnabled(LibraryInfoDownloader.enabled && selectedValues.filter(_.status != LibraryStatus.CanInstall).exists(!_.bundled))
       homepageButton.setEnabled(numSelected == 1)
 
       val installToolTip = if (numSelected == 1) selectedValue.downloadURL.toString else null


### PR DESCRIPTION
Resolved issue where the uninstall button is still clickable for bundled extensions (ex. Arduino and Python). After being clicked, the button would just do nothing.

Bundled extensions that have been updated by the user can still be uninstalled. This would result in the extension reverting to its original version as specified in bundled-libraries.conf.